### PR TITLE
call annotation deleted handler

### DIFF
--- a/src/TextAnnotator.jsx
+++ b/src/TextAnnotator.jsx
@@ -94,6 +94,8 @@ export default class TextAnnotator extends Component {
     this.clearState();
     this.selectionHandler.clearSelection();
     this.highlighter.removeAnnotation(annotation);
+
+    this.props.onAnnotationDeleted(annotation);
   }
 
   /** Cancel button on annotation editor **/


### PR DESCRIPTION
fixes a bug where the `onAnnotationDeleted` handler prop wasn't called and thus made `recogito-js` not emit the `deleteAnnotation` event.

are the added/changed/deleted handlers optional? if so, i'd add a check via `typeof x === 'function'` before calling them.