### PR TITLE
Add admin option

### DIFF
--- a/src/editor/widgets/comment/CommentWidget.jsx
+++ b/src/editor/widgets/comment/CommentWidget.jsx
@@ -32,9 +32,8 @@ const isReadOnlyComment = (body, props) =>  {
   if (props.editable === false)
     return true;
 
-  if (props.env.user?.isAdmin){
+  if (props.env.user?.isAdmin)
     return false
-  }
 
   if (props.editable === 'MINE_ONLY') {
     // The original creator of the body

--- a/src/editor/widgets/comment/CommentWidget.jsx
+++ b/src/editor/widgets/comment/CommentWidget.jsx
@@ -32,6 +32,10 @@ const isReadOnlyComment = (body, props) =>  {
   if (props.editable === false)
     return true;
 
+  if (props.env.user?.isAdmin){
+    return false
+  }
+
   if (props.editable === 'MINE_ONLY') {
     // The original creator of the body
     const creator = body.creator?.id;


### PR DESCRIPTION
Allows the option for user to add auth option that allows a admin user that can edit all annotations if "MINE_ONLY" is set.

```
anno.setAuthInfo({
  id: 'http://www.example.com/rainer',
   displayName: 'rainer',
   isAdmin: true
});
```