### PR TITLE
remove height 100% to avoid overflow

### DIFF
--- a/themes/default/editor/widgets/tag/_tag.scss
+++ b/themes/default/editor/widgets/tag/_tag.scss
@@ -60,7 +60,6 @@
         padding:2px 0;
         color:#fff;
         width:0;
-        height:100%;
         background-color:$ocean;
         @include rounded-corners-right(2px);
 


### PR DESCRIPTION
The tag is currently overflow from the parent div because of this.